### PR TITLE
Fix error: deprecated site config key 'paginate'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Hugo related files
+.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blowfish - Lite Template
-This is a template for the Blowfish Hugo Theme. Feel free to use this repo as a quick way to get started with Blowfish. Please visit [Blowfish's main website](https://github.com/nunocoracao/blowfish) to read the complete documentation.
+This is a template for the Blowfish Hugo Theme. Feel free to use this repo as a quick way to get started with Blowfish. Please visit the[theme documentation](https://blowfish.page/docs/) to read the complete documentation.
 
-The template was built using the [Git option](https://nunocoracao.github.io/blowfish/docs/installation/#install-using-git) from Blowfish's installations instructions.
+The template was built using the [Git option](https://blowfish.page/docs/installation/#install-using-git) from Blowfish's installation instructions.
 
 ![blowfish logo](https://github.com/nunocoracao/blowfish_lite/blob/main/logo.png?raw=true)

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -7,7 +7,6 @@ theme = "blowfish"
 defaultContentLanguage = "en"
 
 enableRobotsTXT = true
-paginate = 20
 summaryLength = 30
 
 buildDrafts = false
@@ -16,6 +15,9 @@ buildFuture = false
 enableEmoji = true
 
 # googleAnalytics = "G-XXXXXXXXX"
+
+[pagination]
+  pagerSize = 20
 
 [taxonomies]
   tag = "tags"


### PR DESCRIPTION
When running the site with latest Hugo version 0.147.7, an error is thrown:

```
ERROR deprecated: site config key paginate was deprecated in Hugo v0.128.0 and subsequently removed.
Use pagination.pagerSize instead.
```

This PR fixes this issue.
This PR closes #1.
